### PR TITLE
add InformerGenerator type and status types for apps objects

### DIFF
--- a/main.go
+++ b/main.go
@@ -6,9 +6,6 @@ import (
 
 	"github.com/demonCoder95/ready-wait-controller/pkg/utils"
 	log "github.com/sirupsen/logrus"
-
-	"k8s.io/client-go/informers"
-	"k8s.io/client-go/tools/cache"
 )
 
 func main() {
@@ -17,25 +14,12 @@ func main() {
 		log.Fatalf("error creating k8s client: %v", err)
 	}
 
-	factory := informers.NewFilteredSharedInformerFactory(clientset, 0, "kube-system", nil)
-	deploymentInformer := factory.Apps().V1().Deployments().Informer()
-
-	deploymentInformer.AddEventHandler(cache.ResourceEventHandlerFuncs{
-		AddFunc: func(obj interface{}) {
-			log.Printf("Deployment added: %s", utils.AsDeployment(obj).Name)
-		},
-		UpdateFunc: func(oldObj, newObj interface{}) {
-			log.Printf("Deployment updated: %s", utils.AsDeployment(oldObj).Name)
-		},
-		DeleteFunc: func(obj interface{}) {
-			log.Printf("Deployment deleted: %s", utils.AsDeployment(obj).Name)
-		},
-	})
+	informer := utils.NewInformerGenerator(clientset, "StatefulSet", "kube-system").GetInformer()
 
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
 
-	deploymentInformer.Run(ctx.Done())
+	informer.Run(ctx.Done())
 
 	log.Infof("Exiting...")
 }

--- a/pkg/utils/types.go
+++ b/pkg/utils/types.go
@@ -1,34 +1,41 @@
 package utils
 
-import (
-	"reflect"
-
-	log "github.com/sirupsen/logrus"
-	appsv1 "k8s.io/api/apps/v1"
-)
-
-// This package provides utility functions for working with Kubernetes objects
-
-func AsDeployment(obj interface{}) *appsv1.Deployment {
-	dep, ok := obj.(*appsv1.Deployment)
-	if !ok {
-		log.Errorf("expected Deployment, got %s: %v", reflect.TypeOf(obj), obj)
-	}
-	return dep
+// DeploymentStatus represents the status of a Deployment
+type DeploymentStatus struct {
+	// The number of total replicas
+	Replicas int32
+	// The number of ready replicas
+	ReadyReplicas int32
+	// The number of updated replicas
+	UpdatedReplicas int32
+	// The number of available replicas
+	AvailableReplicas int32
 }
 
-func AsDaemonSet(obj interface{}) *appsv1.DaemonSet {
-	ds, ok := obj.(*appsv1.DaemonSet)
-	if !ok {
-		log.Errorf("expected DaemonSet, got %s: %v", reflect.TypeOf(obj), obj)
-	}
-	return ds
+// StatefulSetStatus represents the status of a StatefulSet
+type StatefulSetStatus struct {
+	// The number of total replicas
+	Replicas int32
+	// The number of ready replicas
+	ReadyReplicas int32
+	// The number of updated replicas
+	UpdatedReplicas int32
+	// The number of available replicas
+	AvailableReplicas int32
+	// The number of current replicas
+	CurrentReplicas int32
 }
 
-func AsStatefulSet(obj interface{}) *appsv1.StatefulSet {
-	sts, ok := obj.(*appsv1.StatefulSet)
-	if !ok {
-		log.Errorf("expected StatefulSet, got %s: %v", reflect.TypeOf(obj), obj)
-	}
-	return sts
+// DaemonSetStatus represents the status of a DaemonSet
+type DaemonSetStatus struct {
+	// The number of desired replicas
+	DesiredReplicas int32
+	// The number of current replicas
+	CurrentReplicas int32
+	// The number of ready replicas
+	ReadyReplicas int32
+	// The number of Up-to-date replicas
+	UpToDateReplicas int32
+	// The number of available replicas
+	AvailableReplicas int32
 }


### PR DESCRIPTION
Added the `InformerGenerator` type to make the main function cleaner.
Added `*Status` types for `Deployment`, `StatefulSet` and `DaemonSet` types.

Next steps are

1. A local buffer that populates the statuses `v1/apps` types.
2. Accompanying functionality in the informer to update this buffer based on informer events.
3. add the logic of `IsUpdated` function which handles logic for determining if a given object type is up to date.