### PR TITLE
add Makefile and resolve linter errors

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,29 @@
+.PHONY: clean lint build.local
+
+BINARY               ?= ready-wait-controller
+VERSION              ?= $(shell git describe --tags --always --dirty)
+SOURCES              = $(shell find . -name '*.go')
+GO                   ?= go
+GOPKGS               = $(shell $(GO) list ./...)
+BUILD_FLAGS          ?= -v
+LDFLAGS              ?= -X main.version=$(VERSION) -w -s
+
+default: build.local
+
+clean:
+	rm -rf build
+
+test:
+	$(GO) vet -v $(GOPKGS)
+
+lint:$(SOURCES)
+	$(GO) mod download
+	golangci-lint -v run ./...
+
+fmt:
+	$(GO) fmt $(GOPKGS)
+
+build.local: build/$(BINARY)
+
+build/$(BINARY): $(SOURCES)
+	CGO_ENABLED=0 $(GO) build -o build/$(BINARY) $(BUILD_FLAGS) -ldflags "$(LDFLAGS)" ./cmd/$(BINARY)

--- a/cmd/ready-wait-controller/main.go
+++ b/cmd/ready-wait-controller/main.go
@@ -14,7 +14,11 @@ func main() {
 		log.Fatalf("error creating k8s client: %v", err)
 	}
 
-	informer := utils.NewInformerGenerator(clientset, "StatefulSet", "kube-system").GetInformer()
+	objType := "StatefulSet"
+	informer, err := utils.NewInformerGenerator(clientset, objType, "kube-system").GetInformer()
+	if err != nil {
+		log.Fatalf("error creating informer for %s: %v", objType, err)
+	}
 
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()


### PR DESCRIPTION
Introduce `Makefile` for building/linting code and also refactor code to introduce `cmd`.